### PR TITLE
Changed encoding on jscript contents before uploading it

### DIFF
--- a/modules/post/multi/manage/zip.rb
+++ b/modules/post/multi/manage/zip.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Post
     script_file = File.read(File.join(Msf::Config.data_directory, "post", "zip", "zip.js"))
     src.gsub!("\\", "\\\\\\")
     dst.gsub!("\\", "\\\\\\")
-    script_file << "zip(\"#{src}\",\"#{dst}\");"
+    script_file << "zip(\"#{src}\",\"#{dst}\");".force_encoding("UTF-8")
     script_file
   end
 
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Post
     script = wsh_script(datastore['DESTINATION'], datastore['SOURCE'])
     tmp_path = "#{get_env('TEMP')}\\zip.js"
     print_status("script file uploaded to #{tmp_path}")
-    write_file(tmp_path, script)
+    write_file(tmp_path, script.encode("UTF-16LE"))
     cmd_exec("cscript.exe #{tmp_path}")
   end
 


### PR DESCRIPTION
This change fixes a bug where the js file was not read properly by cscript because of a bad character.  It forces the entire string to be UTF-8 and then re-encodes it as UTF-16LE before uploading the file.

